### PR TITLE
fix: use named bindings to link 3D overlays to their properties

### DIFF
--- a/StandAlone/conf_FiducialMarker.xml
+++ b/StandAlone/conf_FiducialMarker.xml
@@ -70,7 +70,12 @@
 	<factory>
 		<bindings>
 			<bind interface="ICamera" to="SolARCameraOpencv" />
-		</bindings>
+      <bind interface="IImageViewer" to="SolARImageViewerOpencv" name="original" properties="original" />
+      <bind interface="IImageViewer" to="SolARImageViewerOpencv" name="grey" properties="grey" />
+      <bind interface="IImageViewer" to="SolARImageViewerOpencv" name="binary" properties="binary" />
+      <bind interface="IImageViewer" to="SolARImageViewerOpencv" name="contours" properties="contours" />
+      <bind interface="IImageViewer" to="SolARImageViewerOpencv" name="filteredContours" properties="filteredContours" />
+    </bindings>
 	</factory>
 	<properties>
 		<configure component="SolARCameraOpencv">
@@ -126,7 +131,7 @@
 				<value>0.157</value>
 			</property>
 		</configure>
-		<configure component="SolARImageViewerOpencv">
+		<configure component="SolARImageViewerOpencv" name="original">
 			<property name="title" type="string" value="Original Image"/>
 			<property name="exitKey" type="Integer" value="27"/>
 			<property name="width" type="Integer" value="0"/>

--- a/StandAlone/main.cpp
+++ b/StandAlone/main.cpp
@@ -74,9 +74,9 @@ int main(int argc, char *argv[]){
         auto camera =xpcfComponentManager->resolve<input::devices::ICamera>();
         auto binaryMarker =xpcfComponentManager->resolve<input::files::IMarker2DSquaredBinary>();
 
-        auto imageViewer =xpcfComponentManager->resolve<display::IImageViewer>();
-        auto imageViewerGrey =xpcfComponentManager->resolve<display::IImageViewer>();
-        auto imageViewerBinary =xpcfComponentManager->resolve<display::IImageViewer>();
+        auto imageViewer =xpcfComponentManager->resolve<display::IImageViewer>("original");
+        auto imageViewerGrey =xpcfComponentManager->resolve<display::IImageViewer>("binary");
+        auto imageViewerBinary =xpcfComponentManager->resolve<display::IImageViewer>("grey");
         auto imageViewerContours =xpcfComponentManager->resolve<display::IImageViewer>("contours");
         auto imageViewerFilteredContours =xpcfComponentManager->resolve<display::IImageViewer>("filteredContours");
 

--- a/StandAlone/main.cpp
+++ b/StandAlone/main.cpp
@@ -75,8 +75,8 @@ int main(int argc, char *argv[]){
         auto binaryMarker =xpcfComponentManager->resolve<input::files::IMarker2DSquaredBinary>();
 
         auto imageViewer =xpcfComponentManager->resolve<display::IImageViewer>("original");
-        auto imageViewerGrey =xpcfComponentManager->resolve<display::IImageViewer>("binary");
-        auto imageViewerBinary =xpcfComponentManager->resolve<display::IImageViewer>("grey");
+        auto imageViewerGrey =xpcfComponentManager->resolve<display::IImageViewer>("grey");
+        auto imageViewerBinary =xpcfComponentManager->resolve<display::IImageViewer>("binary");
         auto imageViewerContours =xpcfComponentManager->resolve<display::IImageViewer>("contours");
         auto imageViewerFilteredContours =xpcfComponentManager->resolve<display::IImageViewer>("filteredContours");
 
@@ -311,7 +311,6 @@ int main(int argc, char *argv[]){
     return 0;
 
 }
-
 
 
 


### PR DESCRIPTION
When in debug, color, greyscale, binary, contours and filtered contours
images were drawn in the same OpenCV window instead of one window for
each, which resulted in a flickery window.
Fixed by adding bindings elements in configuration file that link to
each named property set.